### PR TITLE
sstable: Implement SSTable I/O

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+build --strip never
+build --compilation_mode dbg
+build --copt "-Wall"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To build this, you'll want to have a modern version of [Bazel](https://docs.baze
 ### Building
 To build the DiverDB server binary, run:
 ```
-bazel build //src:diverdb
+bazel build //src:diodb
 ```
 The binary should then show up in your generated `bazel-bin/src` directory.
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "diverdb")
+workspace(name = "diodb")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
@@ -32,7 +32,7 @@ git_repository(
 git_repository(
   name = "com_google_protobuf",
   remote = "https://github.com/google/protobuf.git",
-  tag = "v3.6.1.2",
+  tag = "v3.7.1",
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -9,12 +9,3 @@ cc_grpc_library(
   generate_mocks = True,
   visibility = ["//visibility:public"],
 )
-
-cc_grpc_library(
-  name = "segment_proto",
-  deps = [],
-  srcs = ["segment.proto"],
-  proto_only = True,
-  well_known_protos = True,
-  visibility = ["//visibility:public"],
-)

--- a/proto/server.proto
+++ b/proto/server.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package diverdbserver;
+package diodbserver;
 
 message DBInfoRequest {
 }

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,16 +1,17 @@
 cc_binary(
-  name = "diverdb",
+  name = "diodb",
   srcs = ["main.cc"],
   deps = [
     "@glog//:glog",
     "@com_github_gflags_gflags//:gflags",
     "@com_github_grpc_grpc//:grpc++",
-    ":diverdb_server_lib",
+    ":diodb_server_lib",
   ],
+  copts = ["-std=c++17"],
 )
 
 cc_library(
-  name = "diverdb_server_lib",
+  name = "diodb_server_lib",
   srcs = ["server.cc"],
   hdrs = ["server.h"],
   deps = [
@@ -19,12 +20,14 @@ cc_library(
     "//proto:cc_server_grpc",
     "@com_github_grpc_grpc//:grpc++",
   ],
+  copts = ["-std=c++17"],
 )
 
 cc_library(
   name = "buffer_lib",
   hdrs = ["buffer.h"],
   deps = [],
+  copts = ["-std=c++17"],
 )
 
 cc_library(
@@ -34,10 +37,23 @@ cc_library(
   deps = [
     "@glog//:glog",
     ":buffer_lib",
-    "//proto:segment_proto",
-    ":stats_lib",
+    ":generic_table_lib",
   ],
   visibility = ["//test:__pkg__"],
+)
+
+cc_library(
+  name = "iohandle_lib",
+  srcs = ["iohandle.cc"],
+  hdrs = ["iohandle.h"],
+  deps = [
+    "@glog//:glog",
+    "@boost//:filesystem",
+    "@com_google_protobuf//:protobuf",
+    ":buffer_lib",
+  ],
+  copts = ["-std=c++17"],
+  visibility = ["//test:__pkg__", "//test/mocks:__pkg__"],
 )
 
 cc_library(
@@ -48,14 +64,16 @@ cc_library(
     "@glog//:glog",
     ":memtable_lib",
     "@boost//:filesystem",
+    ":iohandle_lib",
     "@com_google_protobuf//:protobuf",
-    "//proto:segment_proto",
-    ":stats_lib",
+    ":generic_table_lib",
   ],
-  visibility = ["//test:__pkg__"],
+  copts = ["-std=c++17"],
+  visibility = ["//test:__pkg__", "//test/mocks:__pkg__"],
 )
 
 cc_library(
-  name = "stats_lib",
-  hdrs = ["table_stats.h"],
+  name = "generic_table_lib",
+  hdrs = ["table_stats.h", "readable_table_base.h"],
+  copts = ["-std=c++17"],
 )

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,12 +1,55 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
-namespace diverdb {
+namespace diodb {
 
 // TODO: I don't quite know what's needed for this object yet, so rather than
 // implementing a buffer class right now, this will just be a string until I
 // have a better handle on this.
-typedef std::string Buffer;
+typedef std::vector<char> Buffer;
 
-}  // namespace diverdb
+struct Segment {
+  Segment(Buffer&& key_buf, Buffer&& val_buf, const bool del = false)
+      : key_size(key_buf.size()),
+        val_size(val_buf.size()),
+        key(std::move(key_buf)),
+        val(std::move(val_buf)),
+        delete_entry(del) {}
+
+  Segment(const Buffer& key_buf, const Buffer& val_buf, const bool del = false)
+      : key_size(key_buf.size()),
+        val_size(val_buf.size()),
+        key(key_buf),
+        val(val_buf),
+        delete_entry(del) {}
+
+  Segment(const std::string& key_buf, const std::string& val_buf,
+          const bool del = false)
+      : key_size(key_buf.size()),
+        val_size(val_buf.size()),
+        key(key_buf.begin(), key_buf.end()),
+        val(val_buf.begin(), val_buf.end()),
+        delete_entry(del) {}
+
+  Segment() : key_size(0), val_size(0), key(), val(), delete_entry(false) {}
+
+  std::string DebugString() const {
+    std::string k(key.begin(), key.end());
+    std::string v(val.begin(), val.end());
+    return "{ key_size=" + std::to_string(key_size) +
+           ", val_size=" + std::to_string(val_size) + ", key=" + k +
+           ", val=" + v + ", delete=" + std::to_string(delete_entry) + " }";
+  }
+
+  uint32_t key_size;
+  uint32_t val_size;
+  Buffer key;
+  Buffer val;
+  bool delete_entry;
+};
+typedef struct Segment Segment;
+
+}  // namespace diodb

--- a/src/iohandle.cc
+++ b/src/iohandle.cc
@@ -1,0 +1,104 @@
+#include <stdio.h>
+#include <algorithm>
+#include <memory>
+
+#include <glog/logging.h>
+#include <google/protobuf/util/delimited_message_util.h>
+#include <boost/filesystem.hpp>
+#include <boost/functional/hash.hpp>
+
+#include "src/buffer.h"
+#include "src/iohandle.h"
+
+namespace diodb {
+
+IOHandle::IOHandle(const fs::path& filepath) : filepath_(filepath) {
+  LOG(INFO) << "Creating file handle for " << filepath_;
+
+  // If the file exists, open it for update but don't overwrite it. If it
+  // does not exist, create it and begin writing to it.
+  if (fs::exists(filepath_)) {
+    fp_ = fopen(filepath_.generic_string().data(), "r+");
+  } else {
+    fp_ = fopen(filepath_.generic_string().data(), "w+");
+  }
+  filepath_ = fs::canonical(filepath_);
+
+  PCHECK(fp_) << "Unable to open file stream";
+
+  Reset();
+  CHECK_EQ(ferror(fp_), 0);
+}
+
+IOHandle::~IOHandle() { fclose(fp_); }
+
+void IOHandle::Reset() { fseek(fp_, 0, SEEK_SET); }
+
+void IOHandle::ParseNext(Segment* segment) {
+  CHECK(!Eof());
+  CHECK(segment);
+
+  auto validate_return = [](const size_t ret, const int expected_val) {
+    PCHECK(ret == expected_val) << "Error reading segment ret=" << ret;
+  };
+
+  // Key size.
+  size_t ret = fread(&(segment->key_size), sizeof(uint32_t), 1, fp_);
+  validate_return(ret, 1);
+
+  // Val size.
+  ret = fread(&(segment->val_size), sizeof(uint32_t), 1, fp_);
+  validate_return(ret, 1);
+
+  segment->key.resize(segment->key_size);
+  segment->val.resize(segment->val_size);
+
+  // Key.
+  ret = fread(segment->key.data(), segment->key_size, 1, fp_);
+  validate_return(ret, 1);
+
+  // Val.
+  ret = fread(segment->val.data(), segment->val_size, 1, fp_);
+  validate_return(ret, 1);
+
+  // Determine delete.
+  ret = fread(&(segment->delete_entry), sizeof(bool), 1, fp_);
+  validate_return(ret, 1);
+}
+
+bool IOHandle::SegmentWrite(const Segment& segment) {
+  // TODO: Do something with string_view.
+  auto validate_return = [](const size_t ret, const int expected_val) {
+    PCHECK(ret == expected_val) << "Error writing segment ret=" << ret;
+  };
+
+  // Key and val size.
+  size_t ret = fwrite(&segment.key_size, sizeof(uint32_t), 2, fp_);
+  validate_return(ret, 2);
+
+  // Key.
+  ret = fwrite(segment.key.data(), segment.key_size, 1, fp_);
+  validate_return(ret, 1);
+
+  // Val.
+  ret = fwrite(segment.val.data(), segment.val_size, 1, fp_);
+  validate_return(ret, 1);
+
+  // Determine delete.
+  ret = fwrite(&segment.delete_entry, sizeof(bool), 1, fp_);
+  validate_return(ret, 1);
+
+  return true;
+}
+
+void IOHandle::Flush() { PCHECK(fflush(fp_) == 0) << "error flushing"; }
+
+int IOHandle::InputOffset() const {
+  int pos = ftell(fp_);
+  PCHECK(pos >= 0) << "Failed to get offset";
+  return pos;
+}
+
+bool IOHandle::Eof() { return feof(fp_) != 0; }
+
+}  // namespace diodb

--- a/src/iohandle.h
+++ b/src/iohandle.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+
+#include "buffer.h"
+
+namespace fs = boost::filesystem;
+namespace diodb {
+
+class IOHandle {
+ public:
+  IOHandle(const fs::path &filepath);
+  ~IOHandle();
+
+  // Reset all internal state to a post-initialization state.
+  void Reset();
+
+  // Parses the segment at the current stream offset and returns the parsed
+  // message.
+  void ParseNext(Segment *segment);
+
+  // Serializes a segment and writes it to the file.
+  bool SegmentWrite(const Segment &segment);
+
+  // Current offset in the coded stream.
+  int InputOffset() const;
+
+  // Sync writes to disk.
+  void Flush();
+
+  // True if at EOF.
+  bool Eof();
+
+ private:
+  // The filepath being parsed.
+  fs::path filepath_;
+
+  // File pointer.
+  FILE *fp_;
+
+  // Format of information that is persisted on disk during a segment write.
+  // Format is as follows:
+  //
+  //   [key size][val size][key bytes][val bytes]
+  inline static constexpr const char *persisted_fmt_ = "%x%x%s%s";
+};
+
+}  // namespace diodb

--- a/src/main.cc
+++ b/src/main.cc
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-using diverdb::Server::DiverDBServer;
+using diodb::Server::DiverDBServer;
 
 DEFINE_string(
     root_dir, "/tmp/",
@@ -35,13 +35,13 @@ int main(int argc, char *argv[]) {
 
   const string server_address("0.0.0.0:" + FLAGS_server_port);
   LOG(INFO) << "DiverDB server will listen on " << server_address;
-  DiverDBServer diverdb_server;
+  DiverDBServer diodb_server;
 
   // Fire up the DiverDB server.
   LOG(INFO) << "initializing the service";
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-  builder.RegisterService(&diverdb_server);
+  builder.RegisterService(&diodb_server);
   unique_ptr<grpc::Server> server(builder.BuildAndStart());
   server->Wait();
 

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -4,53 +4,62 @@
 
 #include "memtable.h"
 
-namespace diverdb {
+namespace diodb {
 
 Memtable::Memtable() : is_locked_(false) {}
 
 bool Memtable::KeyExists(const Buffer& key) const {
-  if (segment_map_.count(key) > 0) {
-    return !segment_map_.at(key).delete_entry();
+  if (memtable_map_.count(key) > 0) {
+    return !memtable_map_.at(key).delete_entry;
   }
   return false;
 }
 
-void Memtable::Put(Buffer&& key, Buffer&& val) {
+void Memtable::Put(const std::string& key, const std::string& val,
+                   const bool del) {
+  Buffer key_buf(key.begin(), key.end());
+  Buffer val_buf(val.begin(), val.end());
+  Put(std::move(key_buf), std::move(val_buf), del);
+}
+
+void Memtable::Put(Buffer&& key, Buffer&& val, const bool del) {
   CHECK(!is_locked_);
 
-  // TODO: Investigate protobuf arena.
-  Segment segment;
-  segment.set_key(key);
-  segment.set_val(val);
-  segment.set_delete_entry(false);
+  Segment segment(key, val, del);
 
-  if (segment_map_.count(key) > 0) {
-    if (segment_map_[key].delete_entry()) {
+  if (memtable_map_.count(key) > 0) {
+    if (memtable_map_[key].delete_entry) {
       --mutable_num_delete_entries();
       ++mutable_num_valid_entries();
     }
-    segment_map_[key] = std::move(segment);
+    memtable_map_[key] = std::move(segment);
   } else {
-    segment_map_.emplace(std::move(key), std::move(segment));
+    memtable_map_.emplace(std::move(key), std::move(segment));
     ++mutable_num_valid_entries();
   }
 }
 
-Buffer Memtable::Get(const Buffer key) const {
+Buffer Memtable::Get(const Buffer& key) const {
   if (!KeyExists(key)) {
     return Buffer();
   }
-  return segment_map_.at(key).val();
+  return memtable_map_.at(key).val;
 }
 
-void Memtable::Erase(const Buffer& key) {
+void Memtable::Erase(Buffer&& key) {
   CHECK(!is_locked_);
 
-  if (segment_map_.count(key) > 0 && !segment_map_[key].delete_entry()) {
-    segment_map_[key].set_delete_entry(true);
-    --mutable_num_valid_entries();
-    ++mutable_num_delete_entries();
+  if (memtable_map_.count(key) > 0 && memtable_map_[key].delete_entry) {
+    return;
+  } else if (memtable_map_.count(key) > 0 && !memtable_map_[key].delete_entry) {
+    memtable_map_[key].delete_entry = true;
+  } else if (memtable_map_.count(key) == 0) {
+    Buffer buf;
+    Put(std::move(key), std::move(buf), true /* del */);
   }
+
+  --mutable_num_valid_entries();
+  ++mutable_num_delete_entries();
 }
 
-}  // namespace diverdb
+}  // namespace diodb

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -2,32 +2,43 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 #include "buffer.h"
-#include "proto/segment.pb.h"
+#include "readable_table_base.h"
 #include "table_stats.h"
 
-namespace diverdb {
+namespace diodb {
 
-class Memtable : public TableStats {
+class Memtable : public TableStats, public ReadableTable {
  public:
   Memtable();
   ~Memtable() {}
 
-  // Returns true if the given key exists.
-  bool KeyExists(const Buffer& key) const;
+  // ReadableTable.
+  virtual bool KeyExists(const Buffer& key) const override;
+  inline bool KeyExists(const std::string&& key) const override {
+    Buffer k(key.begin(), key.end());
+    return KeyExists(std::move(k));
+  }
+  virtual Buffer Get(const Buffer& key) const override;
+  inline Buffer Get(const std::string&& key) const override {
+    Buffer k(key.begin(), key.end());
+    return Get(std::move(k));
+  }
+  virtual size_t Size() const override { return num_valid_entries(); }
 
   // Inserts a key/value pair into the memtable.
-  void Put(Buffer&& key, Buffer&& val);
-
-  // Gets the value associated with a particular key.
-  Buffer Get(const Buffer key) const;
+  void Put(Buffer&& key, Buffer&& val, const bool del = false);
+  void Put(const std::string& key, const std::string& val,
+           const bool del = false);
 
   // Erases a key/value pair from the memtable.
-  void Erase(const Buffer& key);
-
-  // Returns the number of non-deleted key/value pairs in the memtable.
-  size_t Size() const { return num_valid_entries(); }
+  void Erase(Buffer&& key);
+  void Erase(const std::string&& key) {
+    Buffer k(key.begin(), key.end());
+    Erase(std::move(k));
+  }
 
   // Locks the memtable, rendering it immutable.
   inline void Lock() { is_locked_ = true; }
@@ -41,7 +52,7 @@ class Memtable : public TableStats {
  private:
   // Sorted structure for key/value mappings.
   // TODO: Use some abseil map.
-  std::map<Buffer, Segment> segment_map_;
+  std::map<Buffer, Segment> memtable_map_;
 
   // If the memtable is locked, no further Put/Erase operations are allowed.
   // This is asserted.
@@ -49,15 +60,15 @@ class Memtable : public TableStats {
 
  public:
   // Iterator will just iterate over the internal map type.
-  using MapType = decltype(segment_map_);
+  using MapType = decltype(memtable_map_);
   using iterator = MapType::iterator;
   using const_iterator = MapType::const_iterator;
-  inline iterator begin() { return segment_map_.begin(); }
-  inline iterator end() { return segment_map_.end(); }
-  inline const_iterator begin() const { return segment_map_.begin(); }
-  inline const_iterator end() const { return segment_map_.end(); }
-  inline const_iterator cbegin() const { return segment_map_.cbegin(); }
-  inline const_iterator cend() const { return segment_map_.cend(); }
+  inline iterator begin() { return memtable_map_.begin(); }
+  inline iterator end() { return memtable_map_.end(); }
+  inline const_iterator begin() const { return memtable_map_.begin(); }
+  inline const_iterator end() const { return memtable_map_.end(); }
+  inline const_iterator cbegin() const { return memtable_map_.cbegin(); }
+  inline const_iterator cend() const { return memtable_map_.cend(); }
 };
 
-}  // namespace diverdb
+}  // namespace diodb

--- a/src/readable_table_base.h
+++ b/src/readable_table_base.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+#include "buffer.h"
+
+namespace diodb {
+
+class ReadableTable {
+ public:
+  // Returns true if the given key exists.
+  virtual bool KeyExists(const Buffer& key) const = 0;
+  virtual bool KeyExists(const std::string&& key) const = 0;
+
+  // Gets the value associated with a particular key.
+  virtual Buffer Get(const Buffer& key) const = 0;
+  virtual Buffer Get(const std::string&& key) const = 0;
+
+  // Returns the number of non-deleted key/value pairs in the memtable.
+  virtual size_t Size() const = 0;
+};
+
+}  // namespace diodb

--- a/src/server.cc
+++ b/src/server.cc
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-namespace diverdb {
+namespace diodb {
 namespace Server {
 Status DiverDBServer::GetDBInfo(ServerContext *context,
                                 const DBInfoRequest *request,
@@ -72,4 +72,4 @@ Status DiverDBServer::HolyDiver(ServerContext *context,
 }
 
 }  // namespace Server
-}  // namespace diverdb
+}  // namespace diodb

--- a/src/server.h
+++ b/src/server.h
@@ -7,15 +7,15 @@
 
 #include "proto/server.grpc.pb.h"
 
-using diverdbserver::DBInfoReply;
-using diverdbserver::DBInfoRequest;
-using diverdbserver::DiverDBServerService;
-using diverdbserver::HolyDiverReply;
-using diverdbserver::HolyDiverRequest;
+using diodbserver::DBInfoReply;
+using diodbserver::DBInfoRequest;
+using diodbserver::DiverDBServerService;
+using diodbserver::HolyDiverReply;
+using diodbserver::HolyDiverRequest;
 using grpc::ServerContext;
 using grpc::Status;
 
-namespace diverdb {
+namespace diodb {
 namespace Server {
 
 class DiverDBServer : public DiverDBServerService::Service {
@@ -30,4 +30,4 @@ class DiverDBServer : public DiverDBServerService::Service {
 };
 
 }  // namespace Server
-}  // namespace diverdb
+}  // namespace diodb

--- a/src/sstable.cc
+++ b/src/sstable.cc
@@ -1,44 +1,64 @@
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <algorithm>
 #include <fstream>
 #include <memory>
 
 #include <glog/logging.h>
-#include <google/protobuf/util/delimited_message_util.h>
 #include <boost/filesystem.hpp>
+#include <boost/functional/hash.hpp>
 
-#include "proto/segment.pb.h"
+#include "iohandle.h"
 #include "sstable.h"
 
-DEFINE_uint64(index_offset_bytes, 4096,
+DEFINE_uint64(sstable_index_offset_bytes, 4 * 1024,
               "The minimum number of bytes between each segment that is "
               "referenced in the sparse index. Increasing this will decrease "
               "memory usage, but at the cost of higher read overhead");
 
-using google::protobuf::util::SerializeDelimitedToOstream;
+namespace diodb {
 
-namespace diverdb {
-
+// Constructor for recovering SSTable from an existing file.
 SSTable::SSTable(const fs::path sstable_path)
-    : filepath_(sstable_path), index_offset_bytes_(FLAGS_index_offset_bytes) {
+    : filepath_(sstable_path), table_id_(fs::hash_value(filepath_)) {
   CHECK(fs::exists(sstable_path))
       << "SSTable file " << sstable_path << " does not exist";
+
+  LOG(INFO) << "Restoring SSTable from file " << filepath_
+            << " with id=" << table_id_;
+
+  file_size_ = fs::file_size(filepath_);
+  io_handle_ = std::make_unique<IOHandle>(filepath_);
+  BuildSparseIndexFromFile(filepath_);
 }
 
+// Constructor for flushing a memtable to an SSTable file.
 SSTable::SSTable(const fs::path& new_sstable_path, const Memtable& memtable)
-    : filepath_(new_sstable_path),
-      index_offset_bytes_(FLAGS_index_offset_bytes) {
+    : filepath_(new_sstable_path), table_id_(fs::hash_value(filepath_)) {
   CHECK(!fs::exists(new_sstable_path))
       << "SSTable file " << filepath_ << " exists";
   CHECK(memtable.is_locked())
       << "Attempting to flush an unlocked memtable to " << new_sstable_path;
 
-  LOG(INFO) << "Flushing memtable into SSTable " << filepath_;
-  FlushMemtable(filepath_, memtable);
+  io_handle_ = std::make_unique<IOHandle>(filepath_);
+
+  LOG(INFO) << "Flushing memtable into SSTable " << filepath_
+            << " with id=" << table_id_;
+
+  CHECK(FlushMemtable(filepath_, memtable))
+      << "Error flushing memtable into SSTable " << filepath_
+      << " with id=" << table_id_;
+
+  file_size_ = fs::file_size(filepath_);
+
+  BuildSparseIndexFromFile(filepath_);
 }
 
+// Constructor for merging multiple SSTables into a new one.
 SSTable::SSTable(const fs::path new_sstable_path,
                  const std::vector<SSTablePtr>& sstables)
-    : filepath_(new_sstable_path),
-      index_offset_bytes_(FLAGS_index_offset_bytes) {
+    : filepath_(new_sstable_path), table_id_(fs::hash_value(filepath_)) {
   CHECK(!fs::exists(new_sstable_path))
       << "SSTable file " << filepath_ << " exists";
 
@@ -47,24 +67,94 @@ SSTable::SSTable(const fs::path new_sstable_path,
     parent_paths.append(sst->filepath().generic_string() + ", ");
   }
   LOG(INFO) << "Merging parent SSTables " << parent_paths << "into "
-            << filepath_;
+            << filepath_ << " with id=" << table_id_;
+
+  io_handle_ = std::make_unique<IOHandle>(filepath_);
+
+  // TODO
+  // file_size_ = fs::file_size(filepath_);
+}
+
+void SSTable::BuildSparseIndexFromFile(const fs::path filepath) {
+  LOG(INFO) << "Building sparse index for SSTable " << table_id_;
+
+  if (file_size_ == 0) {
+    LOG(INFO) << "Building sparse index from empty file";
+    return;
+  }
+
+  off_t last_offset = 0;
+  io_handle_->Reset();
+  while (io_handle_->InputOffset() < file_size_) {
+    Segment segment;
+    CHECK_LE(last_offset, io_handle_->InputOffset());
+
+    // Always add the first key in the SSTable and index after the appropriate
+    // number of bytes has been cycled through.
+    if (io_handle_->InputOffset() == 0 ||
+        io_handle_->InputOffset() - last_offset >= KeyIndexOffsetBytes()) {
+      // We're past the minimum file offset, so insert into the sparse index.
+      sparse_index_[std::move(segment.key)] = io_handle_->InputOffset();
+      last_offset = io_handle_->InputOffset();
+    }
+
+    io_handle_->ParseNext(&segment);
+  }
 }
 
 bool SSTable::FlushMemtable(const fs::path& new_sstable_path,
                             const Memtable& memtable) {
-  // Relying on the ofstream destructor to close the fd.
-  fs::ofstream ofs(new_sstable_path);
-
   for (const auto& entry : memtable) {
-    // TODO: Investigate using protobuf zero-copy streams.
-    // TODO: Investigate protobuf arena.
     Segment segment = entry.second;
-    if (!SerializeDelimitedToOstream(segment, &ofs)) {
+    const bool ok = io_handle_->SegmentWrite(segment);
+    if (!ok) {
       return false;
     }
   }
 
+  io_handle_->Flush();
+
   return true;
 }
 
-}  // namespace diverdb
+bool SSTable::KeyExists(const Buffer& key) const {
+  // TODO: Bloom filter to speed this up. It's not really useful without it.
+
+  if (sparse_index_.empty() || key < sparse_index_.begin()->first) {
+    return false;
+  }
+
+  auto it = sparse_index_.lower_bound(key);
+  if (it->first == key) {
+    // Exact match in the sparse index.
+    return true;
+  } else if (it == sparse_index_.cbegin()) {
+    // The index entry is guaranteed to evaluate greater than the key now, so
+    // if it's the smallest item in the index, it's not a match.
+    return false;
+  }
+
+  io_handle_->Reset();
+  Segment segment;
+  while (io_handle_->InputOffset() < file_size_) {
+    io_handle_->ParseNext(&segment);
+    if (key < segment.key) {
+      return false;
+    } else if (key == segment.key) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+Buffer SSTable::Get(const Buffer& key) const {
+  // TODO
+  return Buffer();
+}
+
+off_t SSTable::KeyIndexOffsetBytes() const {
+  return FLAGS_sstable_index_offset_bytes;
+}
+
+}  // namespace diodb

--- a/src/sstable.h
+++ b/src/sstable.h
@@ -1,18 +1,21 @@
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 
 #include "buffer.h"
+#include "iohandle.h"
 #include "memtable.h"
+#include "readable_table_base.h"
 
 namespace fs = boost::filesystem;
-namespace diverdb {
+namespace diodb {
 
-class SSTable {
+class SSTable : public TableStats, public ReadableTable {
  public:
   using SSTablePtr = std::shared_ptr<SSTable>;
 
@@ -32,7 +35,20 @@ class SSTable {
   SSTable(const fs::path new_sstable_path,
           const std::vector<SSTablePtr>& sstables);
 
-  ~SSTable() {}
+  virtual ~SSTable() {}
+
+  // ReadableTable.
+  virtual bool KeyExists(const Buffer& key) const override;
+  inline bool KeyExists(const std::string&& key) const override {
+    Buffer k(key.begin(), key.end());
+    return KeyExists(std::move(k));
+  }
+  virtual Buffer Get(const Buffer& key) const override;
+  inline Buffer Get(const std::string&& key) const override {
+    Buffer k(key.begin(), key.end());
+    return Get(std::move(k));
+  }
+  virtual size_t Size() const override { return num_valid_entries(); }
 
   // Accessors.
   fs::path filepath() { return filepath_; }
@@ -45,17 +61,28 @@ class SSTable {
   bool FlushMemtable(const fs::path& new_sstable_path,
                      const Memtable& memtable);
 
+  // Builds the sparse in-memory segment index from a provided filepath.
+  void BuildSparseIndexFromFile(const fs::path filepath);
+
+  // Returns the minimum key offset bytes for the sparse index.
+  virtual off_t KeyIndexOffsetBytes() const;
+
  private:
   // Filepath of this SSTable.
   fs::path filepath_;
 
-  // The minimum number of bytes between each segment referenced in the
-  // sparse index.
-  size_t index_offset_bytes_;
+  // Size of the SSTable file after being written.
+  int32_t file_size_;
+
+  // Unique identifier for this SSTable. Calculated as a hash of the file path.
+  size_t table_id_;
 
   // A sparse index of the keys and offsets of the associated SSTable entries
   // in the file.
-  std::unordered_map<Buffer, uint64_t> sparse_index_;
+  std::map<Buffer, off_t> sparse_index_;
+
+  // SSTable segment file controller.
+  std::unique_ptr<IOHandle> io_handle_;
 };
 
-}  // namespace diverdb
+}  // namespace diodb

--- a/src/table_stats.h
+++ b/src/table_stats.h
@@ -1,4 +1,4 @@
-namespace diverdb {
+namespace diodb {
 
 class TableStats {
  public:
@@ -23,4 +23,4 @@ class TableStats {
   size_t num_delete_entries_;
 };
 
-}  // namespace diverdb
+}  // namespace diodb

--- a/test/BUILD
+++ b/test/BUILD
@@ -4,6 +4,7 @@ cc_test(
   deps = [
     "@googletest//:gtest_main",
   ],
+  copts = ["-std=c++17"],
 )
 
 cc_test(
@@ -13,6 +14,7 @@ cc_test(
     "@googletest//:gtest_main",
     "//src:memtable_lib",
   ],
+  copts = ["-std=c++17"],
 )
 
 cc_test(
@@ -20,11 +22,10 @@ cc_test(
   srcs = ["sstable_test.cc"],
   deps = [
     "@googletest//:gtest_main",
-    "//src:sstable_lib",
+    "//test/mocks:sstable_mock_lib",
     "@boost//:filesystem",
     "@glog//:glog",
     "@com_google_protobuf//:protobuf",
-    "//proto:segment_proto",
   ],
-  copts = ["--std=c++14"],
+  copts = ["-std=c++17"],
 )

--- a/test/memtable_test.cc
+++ b/test/memtable_test.cc
@@ -1,13 +1,20 @@
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include "src/memtable.h"
 
-namespace diverdb {
+namespace diodb {
 namespace test {
 
 class MemtableTest : public ::testing::Test {
  protected:
   void SetUp() override { memtable_ = Memtable(); }
+  std::vector<char> S2Vec(const std::string&& s) {
+    std::vector<char> v(s.begin(), s.end());
+    return v;
+  }
   Memtable memtable_;
 };
 
@@ -63,19 +70,19 @@ TEST_F(MemtableTest, TestMemtableStats) {
 
 TEST_F(MemtableTest, TestGetBasic) {
   // Should return empty buffer for keys that don't exist.
-  EXPECT_EQ(memtable_.Get("key1"), "");
+  EXPECT_EQ(memtable_.Get("key1"), S2Vec(""));
 
   memtable_.Put("key1", "val1");
-  EXPECT_EQ(memtable_.Get("key1"), "val1");
+  EXPECT_EQ(memtable_.Get("key1"), S2Vec("val1"));
 
   // Verify overwrites.
   memtable_.Put("key1", "val2");
-  EXPECT_EQ(memtable_.Get("key1"), "val2");
+  EXPECT_EQ(memtable_.Get("key1"), S2Vec("val2"));
 
   // Verify Erasure.
   memtable_.Erase("key1");
-  EXPECT_EQ(memtable_.Get("key1"), "");
+  EXPECT_EQ(memtable_.Get("key1"), S2Vec(""));
 }
 
 }  // namespace test
-}  // namespace diverdb
+}  // namespace diodb

--- a/test/mocks/BUILD
+++ b/test/mocks/BUILD
@@ -1,0 +1,10 @@
+cc_library(
+  name = "sstable_mock_lib",
+  hdrs = ["sstable_mock.h"],
+  deps = [
+    "@googletest//:gtest_main",
+    "//src:sstable_lib",
+  ],
+  visibility = ["//test:__pkg__"],
+)
+

--- a/test/mocks/sstable_mock.h
+++ b/test/mocks/sstable_mock.h
@@ -1,0 +1,23 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "src/sstable.h"
+
+namespace diodb {
+namespace test {
+
+class MockSSTable : public SSTable {
+ public:
+  MockSSTable(const fs::path sstable_path) : SSTable(sstable_path) {}
+  MockSSTable(const fs::path& new_sstable_path, const Memtable& memtable)
+      : SSTable(new_sstable_path, memtable) {}
+  MockSSTable(const fs::path new_sstable_path,
+              const std::vector<SSTablePtr>& sstables)
+      : SSTable(new_sstable_path, sstables) {}
+  ~MockSSTable() {}
+
+  MOCK_CONST_METHOD0(KeyIndexOffsetBytes, off_t());
+};
+
+}  // namespace test
+}  // namespace diodb

--- a/test/noop_test.cc
+++ b/test/noop_test.cc
@@ -1,9 +1,9 @@
 #include "gtest/gtest.h"
 
-namespace diverdb {
+namespace diodb {
 namespace test {
 
 TEST(NoopTest, Noop) {}
 
 }  // namespace test
-}  // namespace diverdb
+}  // namespace diodb

--- a/test/sstable_test.cc
+++ b/test/sstable_test.cc
@@ -7,52 +7,75 @@
 #include <vector>
 
 #include <glog/logging.h>
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/util/delimited_message_util.h>
 #include <boost/filesystem.hpp>
 #include "gtest/gtest.h"
 
-#include "proto/segment.pb.h"
 #include "src/memtable.h"
-#include "src/sstable.h"
-
-using google::protobuf::io::FileInputStream;
-using google::protobuf::io::ZeroCopyInputStream;
-using google::protobuf::util::ParseDelimitedFromZeroCopyStream;
+#include "test/mocks/sstable_mock.h"
 
 namespace fs = boost::filesystem;
-namespace diverdb {
+namespace diodb {
 namespace test {
 
 class SSTableTest : public ::testing::Test {
  protected:
-  // Returns a path to a touched file with a given filename.
+  std::vector<char> S2Vec(const std::string&& s) {
+    std::vector<char> v(s.begin(), s.end());
+    return v;
+  }
+  void TearDown() override {
+    for (const auto& fp : files_to_clean_) {
+      fs::remove_all(fp);
+    }
+  }
+
+  // Returns a path to a touched file with a given filename, then cleans up
+  // the file at the end of the test.
   fs::path TouchFile(const std::string& filename) {
-    fs::path filepath = fs::current_path() / filename;
+    fs::path filepath = filename;
     std::ofstream ofs = std::ofstream(filepath.generic_string());
+    files_to_clean_.emplace_back(filepath);
     return filepath;
   }
+
+  // Returns a filepath prefixed by the current working directory, then cleans
+  // up the file at the end of the test.
+  fs::path GetTempFilename(const std::string& filename) {
+    auto p = filename;
+    files_to_clean_.emplace_back(p);
+    if (fs::exists(fs::path(filename))) {
+      fs::remove(fs::path(filename));
+    }
+    return p;
+  }
+
+ private:
+  std::vector<fs::path> files_to_clean_;
 };
 
 TEST_F(SSTableTest, ValidExistingFileTest) {
   // TODO: Create a valid SSTable file here later. Touching a file for now.
   fs::path sstable_filepath = TouchFile("valid_sstable");
 
-  SSTable sstable(sstable_filepath);
+  MockSSTable sstable(sstable_filepath);
 }
 
 TEST_F(SSTableTest, NonExistingFileTest) {
   fs::path sstable_filepath = fs::current_path() / "bogus_filename";
 
   const std::string failure_regex = "SSTable file .* does not exist";
-  ASSERT_DEATH({ SSTable sstable = SSTable(sstable_filepath); }, failure_regex);
+  ASSERT_DEATH({ MockSSTable sstable(sstable_filepath); }, failure_regex);
 }
 
 TEST_F(SSTableTest, VerifyLockedMemtableFlush) {
   Memtable memtable;
   const std::string failure_regex = "unlocked memtable";
-  ASSERT_DEATH({ SSTable sstable = SSTable("some_file", memtable); },
-               failure_regex);
+  ASSERT_DEATH(
+      {
+        MockSSTable sstable(GetTempFilename("VerifyLockedMemtableFlush"),
+                            memtable);
+      },
+      failure_regex);
 }
 
 TEST_F(SSTableTest, UnexpectedExistingFileTestMemtable) {
@@ -61,7 +84,7 @@ TEST_F(SSTableTest, UnexpectedExistingFileTestMemtable) {
   memtable.Lock();
 
   const std::string failure_regex = "SSTable file .* exists";
-  ASSERT_DEATH({ SSTable sstable = SSTable(sstable_filepath, memtable); },
+  ASSERT_DEATH({ MockSSTable sstable(sstable_filepath, memtable); },
                failure_regex);
 }
 
@@ -71,19 +94,18 @@ TEST_F(SSTableTest, UnexpectedExistingFileTestSSTable) {
   fpv.emplace_back(TouchFile("unexpected_file2"));
   fpv.emplace_back(TouchFile("unexpected_file3"));
 
-  std::vector<SSTable::SSTablePtr> sstv;
+  std::vector<MockSSTable::SSTablePtr> sstv;
   for (const auto& p : fpv) {
-    sstv.emplace_back(std::make_shared<SSTable>(p));
+    sstv.emplace_back(std::make_shared<MockSSTable>(p));
   }
 
   const std::string failure_regex = "SSTable file .* exists";
   const auto& existing_file = fpv[0];
-  ASSERT_DEATH({ SSTable sstable = SSTable(existing_file, sstv); },
-               failure_regex);
+  ASSERT_DEATH({ MockSSTable sstable(existing_file, sstv); }, failure_regex);
 }
 
 TEST_F(SSTableTest, MemtableFlushBasic) {
-  const int num_entries = 100;
+  const int num_entries = 32;
 
   // Populate memtable.
   Memtable memtable;
@@ -98,38 +120,64 @@ TEST_F(SSTableTest, MemtableFlushBasic) {
   memtable.Lock();
 
   // Create the SSTable file using the memtable.
-  const std::string filename = "test_file";
-  SSTable sstable(filename, memtable);
+  fs::path filename = GetTempFilename("MemtableFlushBasic");
+  MockSSTable sstable(filename, memtable);
 
   // Verify the file exists.
   ASSERT_TRUE(fs::exists(sstable.filepath()));
 
-  // Deserialize the segments written to disk and verify they are ordered by
-  // key.
-  int fd = open(filename.c_str(), O_RDONLY);
-  ZeroCopyInputStream* input = new FileInputStream(fd);
-  ASSERT_NE(input, nullptr);
   Segment segment;
-  bool clean_eof;
-  std::string last_key;
+
+  IOHandle iohandle(filename);
+  std::vector<char> last_key;
   for (int ii = 0; ii < num_entries; ++ii) {
-    // Make sure the parse is successful for the first 99 entries.
-    ASSERT_TRUE(ParseDelimitedFromZeroCopyStream(&segment, input, &clean_eof));
-    // clean_eof should not be true until the end of the file.
-    ASSERT_FALSE(clean_eof);
+    iohandle.ParseNext(&segment);
     if (ii != 0) {
       // Make sure the SSTable is actually sorted by the keys.
-      ASSERT_LE(last_key, segment.key());
+      ASSERT_LE(last_key, segment.key);
     }
-    last_key = segment.key();
+    last_key = segment.key;
   }
+}
 
-  // There should be no more segments in the file.
-  ASSERT_FALSE(ParseDelimitedFromZeroCopyStream(&segment, input, &clean_eof));
-  ASSERT_TRUE(clean_eof);
+TEST_F(SSTableTest, SSTableParserMalformedFile) {
+  // Let's just build an sstable from a memtable for simplicity.
+  Memtable memtable;
+  for (int ii = 0; ii < 8 * 1024; ++ii) {
+    memtable.Put(std::to_string(ii), std::to_string(ii) + "-val");
+  }
+  memtable.Lock();
+  fs::path filename = GetTempFilename("SSTableParserMalformedFile1");
+  MockSSTable sstable(filename, memtable);
 
-  close(fd);
+  // Corrupt the file by shaving off the last byte. Assuming there's no
+  // mechanism in place to detect two SSTs pointing to same file, so let's just
+  // build a new one on top.
+  auto file_size = fs::file_size(filename);
+  fs::resize_file(filename, file_size - 1);
+  ASSERT_DEATH({ MockSSTable sstable2(filename); }, "Error reading segment");
+}
+
+TEST_F(SSTableTest, SSTableKeyExists) {
+  Memtable memtable;
+  memtable.Put("b", "xxx");
+  memtable.Put("d", "xxx");
+  memtable.Put("f", "xxx");
+  memtable.Lock();
+  fs::path filename = GetTempFilename("SSTableKeyExists");
+  MockSSTable sstable(filename, memtable);
+
+  // Test key absent.
+  ASSERT_FALSE(sstable.KeyExists("a"));
+  ASSERT_FALSE(sstable.KeyExists("c"));
+  ASSERT_FALSE(sstable.KeyExists("e"));
+  ASSERT_FALSE(sstable.KeyExists("g"));
+
+  // Test key present.
+  ASSERT_TRUE(sstable.KeyExists("b"));
+  ASSERT_TRUE(sstable.KeyExists("d"));
+  ASSERT_TRUE(sstable.KeyExists("f"));
 }
 
 }  // namespace test
-}  // namespace diverdb
+}  // namespace diodb


### PR DESCRIPTION
This patch adds a lot... again:
- Memtable flushing to SSTables.
- SSTable sparse indexing.
- SSTable instantiation from existing file.
- KeyExists() function/test for SSTable.
- Renamed back to DioDB. Haters can go ahead and hate.
- Got rid of protobuf serialization for the disk layout in favor of a simple struct.